### PR TITLE
Saved model from mem

### DIFF
--- a/examples/tf_model/main.rs
+++ b/examples/tf_model/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
     let (model_pb, ckpt, var_index) = utilities::load_in_mem(&path)?;
 
     // Create a TensorFlow model resource from data
-    let mut model2 = SavedModel::new().from_in_memory(model_pb, ckpt, var_index)?;
+    let mut model2 = SavedModel::new().from_in_memory(&model_pb, &ckpt, &var_index)?;
     info!("New saved model from in-memory data: {}", model.id());
     sess.register(&mut model2)?;
     info!(

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5668,7 +5668,7 @@ extern "C" {
 extern "C" {
     pub fn vaccel_tf_saved_model_set_model(
         model: *mut vaccel_tf_saved_model,
-        ptr: *mut u8,
+        ptr: *const u8,
         len: size_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -5681,7 +5681,7 @@ extern "C" {
 extern "C" {
     pub fn vaccel_tf_saved_model_set_checkpoint(
         model: *mut vaccel_tf_saved_model,
-        ptr: *mut u8,
+        ptr: *const u8,
         len: size_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -5694,7 +5694,7 @@ extern "C" {
 extern "C" {
     pub fn vaccel_tf_saved_model_set_var_index(
         model: *mut vaccel_tf_saved_model,
-        ptr: *mut u8,
+        ptr: *const u8,
         len: size_t,
     ) -> ::std::os::raw::c_int;
 }

--- a/src/tensorflow/saved_model.rs
+++ b/src/tensorflow/saved_model.rs
@@ -71,12 +71,9 @@ impl SavedModel {
     }
 
     /// Set the in-memory protobuf data
-    fn set_protobuf(&mut self, mut data: Vec<u8>) -> Result<()> {
-        data.shrink_to_fit();
-        let mem = data.leak();
-
+    fn set_protobuf(&mut self, data: &[u8]) -> Result<()> {
         match unsafe {
-            ffi::vaccel_tf_saved_model_set_model(self.inner, mem.as_mut_ptr(), mem.len() as u64)
+            ffi::vaccel_tf_saved_model_set_model(self.inner, data.as_ptr(), data.len() as u64)
                 as u32
         } {
             ffi::VACCEL_OK => Ok(()),
@@ -85,16 +82,10 @@ impl SavedModel {
     }
 
     /// Set the in-memory checkpoint data
-    fn set_checkpoint(&mut self, mut data: Vec<u8>) -> Result<()> {
-        data.shrink_to_fit();
-        let mem = data.leak();
-
+    fn set_checkpoint(&mut self, data: &[u8]) -> Result<()> {
         match unsafe {
-            ffi::vaccel_tf_saved_model_set_checkpoint(
-                self.inner,
-                mem.as_mut_ptr(),
-                mem.len() as u64,
-            ) as u32
+            ffi::vaccel_tf_saved_model_set_checkpoint(self.inner, data.as_ptr(), data.len() as u64)
+                as u32
         } {
             ffi::VACCEL_OK => Ok(()),
             err => Err(Error::Runtime(err)),
@@ -102,12 +93,9 @@ impl SavedModel {
     }
 
     /// Set the in-memory variable index data
-    fn set_var_index(&mut self, mut data: Vec<u8>) -> Result<()> {
-        data.shrink_to_fit();
-        let mem = data.leak();
-
+    fn set_var_index(&mut self, data: &[u8]) -> Result<()> {
         match unsafe {
-            ffi::vaccel_tf_saved_model_set_var_index(self.inner, mem.as_mut_ptr(), mem.len() as u64)
+            ffi::vaccel_tf_saved_model_set_var_index(self.inner, data.as_ptr(), data.len() as u64)
                 as u32
         } {
             ffi::VACCEL_OK => Ok(()),
@@ -118,13 +106,13 @@ impl SavedModel {
     /// Create the resource from in-memory data
     pub fn from_in_memory(
         mut self,
-        protobuf: Vec<u8>,
-        checkpoint: Vec<u8>,
-        variable_index: Vec<u8>,
+        protobuf: &[u8],
+        checkpoint: &[u8],
+        variable_index: &[u8],
     ) -> Result<Self> {
-        self.set_protobuf(protobuf)?;
-        self.set_checkpoint(checkpoint)?;
-        self.set_var_index(variable_index)?;
+        self.set_protobuf(&protobuf)?;
+        self.set_checkpoint(&checkpoint)?;
+        self.set_var_index(&variable_index)?;
 
         match unsafe { ffi::vaccel_tf_saved_model_register(self.inner) } as u32 {
             ffi::VACCEL_OK => Ok(self),


### PR DESCRIPTION
The runtime does not grab the ownership of in-memory objects used to create a SavedModel any more. This PR changes the API and corresponding examples to reflect that.