### PR TITLE
prof: add bindings for vAccel profiling

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5726,6 +5726,106 @@ extern "C" {
     pub fn vaccel_tf_saved_model_id(model: *const vaccel_tf_saved_model) -> vaccel_id_t;
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct prof_sample {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct vaccel_prof_region {
+    pub name: *const ::std::os::raw::c_char,
+    pub name_owned: bool,
+    pub nr_entries: size_t,
+    pub samples: *mut prof_sample,
+    pub size: size_t,
+}
+#[test]
+fn bindgen_test_layout_vaccel_prof_region() {
+    assert_eq!(
+        ::std::mem::size_of::<vaccel_prof_region>(),
+        40usize,
+        concat!("Size of: ", stringify!(vaccel_prof_region))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<vaccel_prof_region>(),
+        8usize,
+        concat!("Alignment of ", stringify!(vaccel_prof_region))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<vaccel_prof_region>())).name as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(vaccel_prof_region),
+            "::",
+            stringify!(name)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<vaccel_prof_region>())).name_owned as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(vaccel_prof_region),
+            "::",
+            stringify!(name_owned)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<vaccel_prof_region>())).nr_entries as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(vaccel_prof_region),
+            "::",
+            stringify!(nr_entries)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<vaccel_prof_region>())).samples as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(vaccel_prof_region),
+            "::",
+            stringify!(samples)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<vaccel_prof_region>())).size as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(vaccel_prof_region),
+            "::",
+            stringify!(size)
+        )
+    );
+}
+impl Default for vaccel_prof_region {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+extern "C" {
+    pub fn vaccel_prof_region_start(region: *mut vaccel_prof_region) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn vaccel_prof_region_stop(region: *const vaccel_prof_region) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn vaccel_prof_region_print(region: *const vaccel_prof_region) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn vaccel_prof_region_init(
+        region: *mut vaccel_prof_region,
+        name: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn vaccel_prof_region_destroy(region: *mut vaccel_prof_region) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct __locale_data {
     pub _address: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::fmt;
 
 pub mod ffi;
 pub mod ops;
+pub mod prof;
 pub mod resource;
 pub mod session;
 pub mod tensorflow;

--- a/src/prof/mod.rs
+++ b/src/prof/mod.rs
@@ -1,0 +1,61 @@
+use crate::ffi;
+use crate::{Error, Result};
+
+use std::ffi::CString;
+
+/// A vAccel profile region
+///
+/// This describes a region in a vAccel application
+/// for which we can gather stats
+#[derive(Debug)]
+pub struct ProfRegion {
+    inner: ffi::vaccel_prof_region,
+}
+
+impl ProfRegion {
+    /// Create a new profile region
+    ///
+    /// This will allocate and initialize a profile region
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the region
+    pub fn new(name: &str) -> Result<Self> {
+        let c_name = CString::new(name).map_err(|_| Error::InvalidArgument)?;
+
+        let mut inner = ffi::vaccel_prof_region::default();
+
+        match unsafe { ffi::vaccel_prof_region_init(&mut inner, c_name.as_c_str().as_ptr()) as u32 }
+        {
+            ffi::VACCEL_OK => Ok(ProfRegion { inner }),
+            err => Err(Error::Runtime(err)),
+        }
+    }
+
+    pub fn enter(&mut self) -> Result<()> {
+        match unsafe { ffi::vaccel_prof_region_start(&mut self.inner) as u32 } {
+            ffi::VACCEL_OK => Ok(()),
+            err => Err(Error::Runtime(err)),
+        }
+    }
+
+    pub fn exit(&mut self) -> Result<()> {
+        match unsafe { ffi::vaccel_prof_region_stop(&mut self.inner) as u32 } {
+            ffi::VACCEL_OK => Ok(()),
+            err => Err(Error::Runtime(err)),
+        }
+    }
+
+    pub fn print(&self) -> Result<()> {
+        match unsafe { ffi::vaccel_prof_region_print(&self.inner) as u32 } {
+            ffi::VACCEL_OK => Ok(()),
+            err => Err(Error::Runtime(err)),
+        }
+    }
+}
+
+impl Drop for ProfRegion {
+    fn drop(&mut self) {
+        unsafe { ffi::vaccel_prof_region_destroy(&mut self.inner) };
+    }
+}


### PR DESCRIPTION
Expose a type that wraps `vaccel_prof_region` and let us use the vAccel
API to profile regions of code.

Signed-off-by: Babis Chalios <mail@bchalios.io>